### PR TITLE
[Untested] Fix SickRage/SickRage#3070

### DIFF
--- a/SickRage.iss
+++ b/SickRage.iss
@@ -330,8 +330,10 @@ var
   Nssm: String;
   ResultCode: Integer;
   OldProgressString: String;
+  WindowsVersion: TWindowsVersion;
 begin
   Nssm := ExpandConstant('{app}\Installer\nssm.exe')
+  GetWindowsVersionEx(WindowsVersion);
 
   OldProgressString := WizardForm.StatusLabel.Caption;
   WizardForm.StatusLabel.Caption := ExpandConstant('Installing {#AppName} service...')
@@ -342,6 +344,10 @@ begin
   Exec(Nssm, ExpandConstant('set "{#AppServiceName}" AppStopMethodSkip 6'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   Exec(Nssm, ExpandConstant('set "{#AppServiceName}" AppStopMethodConsole 20000'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   Exec(Nssm, ExpandConstant('set "{#AppServiceName}" AppEnvironmentExtra "PATH={app}\Git\cmd;%PATH%"'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+
+  if Version.NTPlatform and (WindowsVersion.Major = 10) and (WindowsVersion.Minor = 0) and (WindowsVersion.Build > 14393) then begin
+    Exec(Nssm, ExpandConstant('set "{#AppServiceName}" AppNoConsole 1'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+  end;
 
   WizardForm.StatusLabel.Caption := OldProgressString;
 end;

--- a/SickRage.iss
+++ b/SickRage.iss
@@ -345,7 +345,7 @@ begin
   Exec(Nssm, ExpandConstant('set "{#AppServiceName}" AppStopMethodConsole 20000'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   Exec(Nssm, ExpandConstant('set "{#AppServiceName}" AppEnvironmentExtra "PATH={app}\Git\cmd;%PATH%"'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
 
-  if Version.NTPlatform and (WindowsVersion.Major = 10) and (WindowsVersion.Minor = 0) and (WindowsVersion.Build > 14393) then begin
+  if WindowsVersion.NTPlatform and (WindowsVersion.Major = 10) and (WindowsVersion.Minor = 0) and (WindowsVersion.Build > 14393) then begin
     Exec(Nssm, ExpandConstant('set "{#AppServiceName}" AppNoConsole 1'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   end;
 


### PR DESCRIPTION
Set `AppNoConsole` to 1 if Windows 10 build is newer than the [Anniversary Update (b14393)](https://en.wikipedia.org/wiki/Windows_10_version_history#Version_1607_.28Anniversary_Update.29)
based on https://github.com/SickRage/SickRage/issues/3070#issuecomment-292735744 (thanks to @scott3n2)


### If this works, it will...
Fix SickRage/SickRage#3070
Fix SickRage/SickRage#3607
Fix #5 