### PR TITLE
Update installer version to v0.5.1 / 10004

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# SickRageInstaller
+SickRageInstaller [![Build status](https://ci.appveyor.com/api/projects/status/yub1d59qlfub8uvb/branch/master?svg=true)](https://ci.appveyor.com/project/sharkykh/sickrageinstaller/branch/master)
+=========
 A Windows Installer for SickRage
 
 **NOTE:** This installer intentionally ignores any existing installations of Git or Python you might already have installed on your system. If you would prefer to use those versions, we recommend installing SickRage manually.

--- a/SickRage.iss
+++ b/SickRage.iss
@@ -1,6 +1,6 @@
 #include <.\idp\idp.iss>
 
-#define SickRageInstallerVersion "v0.5"
+#define SickRageInstallerVersion "v0.5.1"
 
 #define AppId "{{B0D7EA3E-CC34-4BE6-95D5-3C3D31E9E1B2}"
 #define AppName "SickRage"
@@ -14,8 +14,8 @@
 
 #define DefaultPort 8081
 
-#define InstallerVersion 10003
-#define InstallerSeedUrl "https://raw.github.com/VinceVal/SickRageInstaller/master/seed.ini"
+#define InstallerVersion 10004
+#define InstallerSeedUrl "https://raw.githubusercontent.com/SickRage/SickRageInstaller/master/seed.ini"
 #define AppRepoUrl "https://github.com/SickRage/SickRage.git"
 
 [Setup]
@@ -45,7 +45,6 @@ WizardSmallImageFile=assets\WizardSmall.bmp
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "utils\unzip.exe"; Flags: dontcopy
 Source: "assets\sickrage.ico"; DestDir: "{app}\Installer"
 Source: "assets\github.ico"; DestDir: "{app}\Installer"
 Source: "utils\nssm32.exe"; DestDir: "{app}\Installer"; DestName: "nssm.exe"; Check: not Is64BitInstallMode

--- a/SickRage.iss
+++ b/SickRage.iss
@@ -38,7 +38,6 @@ UninstallFilesDir={app}\Installer
 ExtraDiskSpaceRequired=524288000
 SetupIconFile=assets\sickrage.ico
 WizardImageFile=assets\Wizard.bmp
-WizardImageBackColor=$666666
 WizardSmallImageFile=assets\WizardSmall.bmp
 
 [Tasks]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,46 @@
+version: '{build}'
+pull_requests:
+  do_not_increment_build_number: true
+max_jobs: 1
+image: Visual Studio 2017
+
+skip_tags: true
+only_commits:
+  files:
+    - SickRage.iss
+    - idp/**
+    - assets/**
+    - appveyor.yml
+
+install:
+  - ps: choco install -y --no-progress InnoSetup
+
+build_script:
+  - cmd: iscc.exe /Q SickRage.iss
+
+test: off
+
+artifacts:
+  - path: Output\SickRageInstaller.exe
+    name: SickRageInstaller.exe
+
+before_deploy:
+  - ps: $env:ReleaseVersion = select-string -Path .\SickRage.iss -Pattern '^#define\sSickRageInstallerVersion\s"(v[\d.]+)"' | % { $($_.matches.groups[1]).Value }
+  - ps: >-
+      $InstallerVersion = select-string -Path .\SickRage.iss -Pattern '^#define\sInstallerVersion\s([\d]+)' | % { $($_.matches.groups[1]).Value };
+      $SeedVersion = select-string -Path .\seed.ini -Pattern '^Version=([\d]+)' | % { $($_.matches.groups[1]).Value };
+      If ($InstallerVersion -ne $SeedVersion) {
+        throw "Update seed version differs from version in source code!`n" +
+              "`tVersion in source code: $InstallerVersion`n" +
+              "`tVersion in seed file:   $SeedVersion"
+      }
+
+deploy:
+  - provider: GitHub
+    tag: $(ReleaseVersion)
+    draft: true                # release as a draft
+    auth_token:
+      secure: Jmp8JMqRCuCKR7RfsMPkQccXatcLQXe6PfYhkRTvaGK5h7ap6FFOG4he+ppOWzuI
+    artifact: SickRageInstaller.exe
+    on:
+      branch: master           # release from master branch only

--- a/seed.ini
+++ b/seed.ini
@@ -1,6 +1,6 @@
 [Installer]
-Version=10003
-DownloadUrl=https://github.com/VinceVal/SickRageInstaller
+Version=10004
+DownloadUrl=https://github.com/SickRage/SickRageInstaller
 
 [Python.x86]
 url=https://www.python.org/ftp/python/2.7.13/python-2.7.13.msi
@@ -13,11 +13,11 @@ size=20082688
 sha1=d9113142bae8829365c595735e1ad1f9f5e2894c
 
 [Git.x86]
-url=https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/PortableGit-2.12.2.2-32-bit.7z.exe
-size=35052200
-sha1=d1399f359f9c9b6480dad372466d8fd558eeb49f
+url=https://github.com/git-for-windows/git/releases/download/v2.12.1.windows.1/PortableGit-2.12.1-32-bit.7z.exe
+size=34968688
+sha1=612c2414470a77a7cfa93e93d720eae593e6edf7
 
 [Git.x64]
-url=https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/PortableGit-2.12.2.2-64-bit.7z.exe
-size=35015800
-sha1=1a50d1be3405d70d36eeb94dd9814341a5935103
+url=https://github.com/git-for-windows/git/releases/download/v2.12.1.windows.1/PortableGit-2.12.1-64-bit.7z.exe
+size=34921208
+sha1=fb4b0875adfed0f10294a7c601c0838ee209b65d


### PR DESCRIPTION
Important notes:
---
- Currently the installer downloads the `seed.ini` file from VinceVal's repo.
This PR will change that to this repo (because it doesn't look like VinceVal is still maintaining this)
~**I think we should wait until I get the chance to setup AppVeyor to automatically compile the installer.**~
- I fast-forwarded `dev` to be even with `master` so we should use it like in SickRage repo.

---

### Changes in this pull request:
- **AppVeyor will now build/compile the installer. (#11 was merged here)**
The compiled installer is always available in the [artifacts section of the build](https://ci.appveyor.com/project/sharkykh/sickrageinstaller/build/artifacts). On push the master a release is created and the installer is attached.
- Update installer version to v0.5.1 / 10004. ~**This will cause all already downloaded installers to present a message that a newer version is available.**~
Previously downloaded installers are using VinceVal's seed.ini, so no message
- Update seed url to SickRage/SickRageInstaller (doesn't look like VinceVal is still maintaining this)
- Rollback Git version because PortableGit SFX on v2.12.2(2) doesn't have an `-InstallPath` switch.
- Fix compiler warning about WizardImageBackColor: `Warning: The [Setup] section directive "WizardImageBackColor" is obsolete and ignored in this version of Inno Setup.`
- Remove reference to the removed unzip.exe (wasn't used)

---

### [SickRageInstaller.zip](https://github.com/SickRage/SickRageInstaller/files/911824/SickRageInstaller.zip)