### PR TITLE
Auto release using AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# SickRageInstaller
+SickRageInstaller [![Build status](https://ci.appveyor.com/api/projects/status/yub1d59qlfub8uvb/branch/master?svg=true)](https://ci.appveyor.com/project/sharkykh/sickrageinstaller/branch/master)
+=========
 A Windows Installer for SickRage
 
 **NOTE:** This installer intentionally ignores any existing installations of Git or Python you might already have installed on your system. If you would prefer to use those versions, we recommend installing SickRage manually.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,46 @@
+version: '{build}'
+pull_requests:
+  do_not_increment_build_number: true
+max_jobs: 1
+image: Visual Studio 2017
+
+skip_tags: true
+only_commits:
+  files:
+    - SickRage.iss
+    - idp/**
+    - assets/**
+    - appveyor.yml
+
+install:
+  - ps: choco install -y --no-progress InnoSetup
+
+build_script:
+  - cmd: iscc.exe /Q SickRage.iss
+
+test: off
+
+artifacts:
+  - path: Output\SickRageInstaller.exe
+    name: SickRageInstaller.exe
+
+before_deploy:
+  - ps: $env:ReleaseVersion = select-string -Path .\SickRage.iss -Pattern '^#define\sSickRageInstallerVersion\s"(v[\d.]+)"' | % { $($_.matches.groups[1]).Value }
+  - ps: >-
+      $InstallerVersion = select-string -Path .\SickRage.iss -Pattern '^#define\sInstallerVersion\s([\d]+)' | % { $($_.matches.groups[1]).Value };
+      $SeedVersion = select-string -Path .\seed.ini -Pattern '^Version=([\d]+)' | % { $($_.matches.groups[1]).Value };
+      If ($InstallerVersion -ne $SeedVersion) {
+        throw "Update seed version differs from version in source code!`n" +
+              "`tVersion in source code: $InstallerVersion`n" +
+              "`tVersion in seed file:   $SeedVersion"
+      }
+
+deploy:
+  - provider: GitHub
+    tag: $(ReleaseVersion)
+    draft: true                # release as a draft
+    auth_token:
+      secure: Jmp8JMqRCuCKR7RfsMPkQccXatcLQXe6PfYhkRTvaGK5h7ap6FFOG4he+ppOWzuI
+    artifact: SickRageInstaller.exe
+    on:
+      branch: master           # release from master branch only


### PR DESCRIPTION
@miigotu Tested on a fork.
But it isn't automated here for some reason. (I manually started a build for the branch)
Probably needs to be enabled.

I now think that when you started using AppVeyor for SickRage/SickRage,
you should have created an account for the organization instead
and given access to the team members... like Travis is set up.

----

- Will **build/compile** on every branch and pull request, but not on tags (indended).
- Will **deploy** only when pushed to master,
so ready everything in dev then push to master.

- Creates a release **draft** based on the value of the `#define SickRageInstallerVersion` line in `SickRage.iss`, and attaches the compiled installer.
- Fails if the value of `#define InstallerVersion` in `SickRage.iss` differs from the value of `Version` in `seed.ini` **to make sure that the users will get the update**.

More ideas...
---
- In the build section, we can download the files specified in `seed.ini` and compare the SHA1 hashes and sizes to make sure they're correct, making sure the installer will work for the users.